### PR TITLE
Change back to use rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://ruby.taobao.org/'
+source 'https://rubygems.org'
 
 gem 'sinatra'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: https://ruby.taobao.org/
+  remote: https://rubygems.org
   specs:
     puma (2.8.2)
       rack (>= 1.1, < 2.0)


### PR DESCRIPTION
s2i build with ruby images failed due to below error:

  Fetching gem metadata from https://ruby.taobao.org/.......
      Installing json (1.8.1)
      
      OpenSSL::SSL::SSLError: hostname "upyun.gems.ruby-china.org" does not match the server certificate

So change back to use official gems